### PR TITLE
start_timer function now returns false if already running.

### DIFF
--- a/src/Header/timer.enh.h
+++ b/src/Header/timer.enh.h
@@ -439,7 +439,7 @@ namespace enh
 		inline bool start_timer() noexcept
 		{
 			if (isTimerCounting())
-				return true;
+				return false;
 			O3_LIB_LOG_LINE;
 			clear_stop();
 			elapsed_cycles = 0;


### PR DESCRIPTION
Earlier returns true regardles of whether timer was already running