### PR TITLE
Restructured several functions and classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ Exists in `namespace enh`.
 
 * Version of the Enhance library
 
+
+_______________________________________________________________________________
+## General
+_______________________________________________________________________________
+
+General is a library of functions for general use.
+
+Exists in `namespace enh`.
+
+### Headers :
+
+`general.enh.h`
+
+### The Library 
+
+* Check if bits are high in a variable (also constexpr).
+* Check if value is within bounds (also constexpr).
+* Signum function and inclusive_ration (also constexpr).
+
 _______________________________________________________________________________
 ## Diagnose
 _______________________________________________________________________________
@@ -68,8 +87,8 @@ _______________________________________________________________________________
 ## Error Handling
 _______________________________________________________________________________
 
-Common is a library that contains functions and classes for various error
- handling uses.
+Error Handling Library is a library that contains functions and classes for 
+various error handling uses.
 
 Exists in `namespace enh`.
 
@@ -83,9 +102,6 @@ Exists in `namespace enh`.
 
 * Enumeration to provide 3 possible outcomes (good, error, blocked due to 
 previous error) for functions.
-
-* `constexpr` constants signum and inclusive ratio, which rounds up in integer 
-division.
 
 _______________________________________________________________________________
 ## Concurrent
@@ -135,6 +151,8 @@ project.
 
 * %Framework - `framework.enh.h`
 
+* %General - `general.enh.h`
+
 * %Error_Base - `error_base.enh.h`
 
 * %Debug - `logger.enh.h, logger.cpp`
@@ -149,14 +167,15 @@ project.
 
 Here the coulumn means depends on.
 
-| Header                | Framework |  Error_Base | Debug | Queued_Process  | Counter | Timer |
-|         :----:        |  :----:   |    :---:    | :---: |      :---:      |  :---:  | :---: |
-| Framework             | O         | X           | X     | X               | X       | X     |
-| Error_Base            | Y         | O           | Y     | X               | X       | X     |
-| Debug                 | Y         | X           | O     | X               | X       | X     |
-| Queued_Process        | Y         | Y           | Y     | O               | X       | X     |
-| Counter               | Y         | X           | X     | X               | O       | X     |
-| Timer                 | Y         | X           | Y     | X               | X       | O     |
+| Header                | Framework |  General  |  Error_Base | Debug | Queued_Process  | Counter | Timer |
+|         :----:        |  :----:   |  :----:   |   :---:     | :---: |      :---:      |  :---:  | :---: |
+| Framework             | O         | X         | X           | X     | X               | X       | X     |
+| General               | Y         | O         | X           | X     | X               | X       | X     |
+| Error_Base            | Y         | Y         | O           | Y     | X               | X       | X     |
+| Debug                 | Y         | X         | X           | O     | X               | X       | X     |
+| Queued_Process        | Y         | Y         | Y           | Y     | O               | X       | X     |
+| Counter               | Y         | X         | X           | X     | X               | O       | X     |
+| Timer                 | Y         | X         | X           | Y     | X               | X       | O     |
 
 Row Debug, coloumn Framework is Y, this means Debug module headers includes headers in Framework module.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Exists in `namespace enh`.
 
 ### Headers :
 
-`common.enh.h`
+`error_base.enh.h`
 
 ### The Library 
 
@@ -135,7 +135,7 @@ project.
 
 * %Framework - `framework.enh.h`
 
-* %Common - `common.enh.h`
+* %Error_Base - `error_base.enh.h`
 
 * %Debug - `logger.enh.h, logger.cpp`
 
@@ -149,14 +149,14 @@ project.
 
 Here the coulumn means depends on.
 
-| Header                | Framework |  Common | Debug | Queued_Process  | Counter | Timer |
-|         :----:        |  :----:   |  :---:  | :---: |      :---:      |  :---:  | :---: |
-| Framework             | O         | X       | X     | X               | X       | X     |
-| Common                | Y         | O       | Y     | X               | X       | X     |
-| Debug                 | Y         | X       | O     | X               | X       | X     |
-| Queued_Process        | Y         | Y       | Y     | O               | X       | X     |
-| Counter               | Y         | X       | X     | X               | O       | X     |
-| Timer                 | Y         | X       | Y     | X               | X       | O     |
+| Header                | Framework |  Error_Base | Debug | Queued_Process  | Counter | Timer |
+|         :----:        |  :----:   |    :---:    | :---: |      :---:      |  :---:  | :---: |
+| Framework             | O         | X           | X     | X               | X       | X     |
+| Error_Base            | Y         | O           | Y     | X               | X       | X     |
+| Debug                 | Y         | X           | O     | X               | X       | X     |
+| Queued_Process        | Y         | Y           | Y     | O               | X       | X     |
+| Counter               | Y         | X           | X     | X               | O       | X     |
+| Timer                 | Y         | X           | Y     | X               | X       | O     |
 
 Row Debug, coloumn Framework is Y, this means Debug module headers includes headers in Framework module.
 

--- a/documentation/examples/error_base_ex.cpp
+++ b/documentation/examples/error_base_ex.cpp
@@ -1,4 +1,4 @@
-#include <common.enh.h>
+#include <error_base.enh.h>
 #include <iostream>
 
 class derived_type : public enh::error_base<unsigned char>

--- a/documentation/examples/tristate_ex.cpp
+++ b/documentation/examples/tristate_ex.cpp
@@ -1,4 +1,4 @@
-#include <common.enh.h>
+#include <error_base.enh.h>
 #include <iostream>
 
 enh::tristate foo(std::string len)

--- a/src/Header/error_base.enh.h
+++ b/src/Header/error_base.enh.h
@@ -32,7 +32,7 @@
 
 #include <atomic>
 #include "framework.enh.h"
-
+#include "general.enh.h"
 #include "logger.enh.h"
 
 
@@ -71,28 +71,6 @@ namespace enh
 		) noexcept
 	{
 		return (e != tristate::GOOD);
-	}
-
-	/**
-		\brief Check if all the bits high in parameter 'field' are high in 
-		parameter 'in'.\n
-		
-		<h3>Return</h3>
-		Returns true if all bits on in 'field' are on in
-		'in'.\n
-
-		<h3>Template</h3>
-		-#  <code>enumT</code> : The enumeration type (preffered) that is to
-		be compared.\n
-
-	*/
-	template<class enumT>
-	inline bool checkField(
-		enumT in /**< : <i>in</i> : The field to check.*/,
-		enumT field /**< : <i>in</i> : The fields to check for.*/
-	) noexcept
-	{
-		return ((in | field) == in);
 	}
 
 	/**
@@ -296,22 +274,7 @@ namespace enh
 #endif
 	};
 
-	/**
-		\brief the signum function, value is 0 if val is 0, 1 if val > 0, 
-		-1 if  val < 0.
-	*/
-	template<long long val>
-	constexpr short signum = (val > 0) ? 1 : -1;
-
-	template<>
-	constexpr short signum<0> = 0;
-
-	/**
-		\brief The rounded up value of the ratio num / denom.
-	*/
-	template<unsigned long long num, unsigned long long denom>
-	constexpr unsigned long long inclusive_ratio = num / denom +
-		signum<num % denom>;
+	
 
 }
 

--- a/src/Header/error_base.enh.h
+++ b/src/Header/error_base.enh.h
@@ -1,5 +1,5 @@
 /** ***************************************************************************
-	\file common.enh.h
+	\file error_base.enh.h
 	
 	\brief The file to declare common items
  

--- a/src/Header/error_base.enh.h
+++ b/src/Header/error_base.enh.h
@@ -1,7 +1,7 @@
 /** ***************************************************************************
 	\file error_base.enh.h
 	
-	\brief The file to declare common items
+	\brief The file to declare Error Handling classes and functions
  
 	Created 24 March 2020	
 		
@@ -26,9 +26,9 @@
 
 
 
-#ifndef COMMON_ENH_H
+#ifndef ERROR_BASE_ENH_H
 
-#define COMMON_ENH_H				common.enh.h
+#define ERROR_BASE_ENH_H				error_base.enh.h
 
 #include <atomic>
 #include "framework.enh.h"

--- a/src/Header/general.enh.h
+++ b/src/Header/general.enh.h
@@ -34,3 +34,45 @@
 #include "framework.enh.h"
 
 
+namespace enh
+{
+	/**
+		\brief Check if all the bits high in parameter 'field' are high in
+		parameter 'in'.\n
+
+		<h3>Return</h3>
+		Returns true if all bits on in 'field' are on in
+		'in'.\n
+
+		<h3>Template</h3>
+		-#  <code>enumT</code> : The enumeration type (preffered) that is to
+		be compared.\n
+
+	*/
+	template<class enumT>
+	inline bool checkField(
+		enumT in /**< : <i>in</i> : The field to check.*/,
+		enumT field /**< : <i>in</i> : The fields to check for.*/
+	) noexcept
+	{
+		return ((in | field) == in);
+	}
+
+	/**
+		\brief the signum function, value is 0 if val is 0, 1 if val > 0,
+		-1 if  val < 0.
+	*/
+	template<long long val>
+	constexpr short signum = (val > 0) ? 1 : -1;
+
+	template<>
+	constexpr short signum<0> = 0;
+
+	/**
+		\brief The rounded up value of the ratio num / denom.
+	*/
+	template<unsigned long long num, unsigned long long denom>
+	constexpr unsigned long long inclusive_ratio = num / denom +
+		signum<num %denom>;
+
+}

--- a/src/Header/general.enh.h
+++ b/src/Header/general.enh.h
@@ -31,6 +31,7 @@
 #define GENERAL_ENH_H				general.enh.h
 
 #include <atomic>
+#include <type_traits>
 #include "framework.enh.h"
 
 
@@ -59,8 +60,10 @@ namespace enh
 	}
 
 	/**
-		\brief the signum function, value is 0 if val is 0, 1 if val > 0,
+		\brief [[deprecated]] The signum function, value is 0 if val is 0, 1 if val > 0,
 		-1 if  val < 0.
+
+		<b> DEPRECATED </b> : Use constexpr function signum_fn.
 	*/
 	template<long long val>
 	constexpr short signum = (val > 0) ? 1 : -1;
@@ -69,10 +72,59 @@ namespace enh
 	constexpr short signum<0> = 0;
 
 	/**
-		\brief The rounded up value of the ratio num / denom.
+		\brief [[deprecated]] The rounded up value of the ratio num / denom.
+
+		<b> DEPRECATED </b> : Use constexpr function incl_ratio.
 	*/
 	template<unsigned long long num, unsigned long long denom>
 	constexpr unsigned long long inclusive_ratio = num / denom +
 		signum<num %denom>;
 
+
+	/**
+		\brief The mathematical signum function to extract sign.
+
+		<h3>Template</h3>
+		<code>class arithmetic</code> : The arithmetic type of the argument.
+
+		<h3>Return</h3>
+		The sign : -1 if argument is negative, +1 if argument is postive, 0 
+		if argument is 0
+	*/
+	template<class arithmetic>
+	constexpr short signum_fn(arithmetic arg)
+	{
+		static_assert(std::is_arithmetic_v<arithmetic>, "signum function takes an arithmetic type");
+		if (arg > 0)
+			return 1;
+		else if (arg < 0)
+			return -1;
+		else
+			return 0;
+	}
+
+	/**
+		\brief The inclusive ratio (ratio rounded up while deviding).
+
+		<h3>Template</h3>
+		<code>class integral</code> : The integral type of the argument.
+
+		<h3>Return</h3>
+		The rounded up value, returns num / denom rounded up.
+
+		eg : incl_ratio(25,3) == 9
+	*/
+	template<class integral>
+	constexpr integral incl_ratio(
+		integral num /*< : <i>in</i> : The numerator of fraction.*/,
+		integral denom /*< : <i>in</i> : The denominator of fraction.*/
+	)
+	{
+		static_assert(std::is_integral_v<integral> &&
+			std::is_unsigned_v < integral>, "inclusive ratio is for integral types");
+		return (num / denom) + signum_fn(num % denom);
+	}
+
 }
+
+#endif

--- a/src/Header/general.enh.h
+++ b/src/Header/general.enh.h
@@ -1,0 +1,36 @@
+/** ***************************************************************************
+	\file general.enh.h
+
+	\brief The file to declare general purpose classes and functions
+
+	Created 11 May 2020
+
+	This file is part of Enhance.
+
+	Copyright 2020 Harith Manoj <harithpub@gmail.com>
+
+	Enhance is free software : you can redistribute it and /or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Enhance is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Enhance. If not, see < https://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+
+
+#ifndef GENERAL_ENH_H
+
+#define GENERAL_ENH_H				general.enh.h
+
+#include <atomic>
+#include "framework.enh.h"
+
+

--- a/src/Header/general.enh.h
+++ b/src/Header/general.enh.h
@@ -14,7 +14,7 @@
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
 
-	Enhance is distributed in the hope that it will be useful,
+	Enhance is distributed base the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
 	GNU General Public License for more details.
@@ -38,12 +38,11 @@
 namespace enh
 {
 	/**
-		\brief Check if all the bits high in parameter 'field' are high in
-		parameter 'in'.\n
+		\brief Check if all the bits high in parameter 'toCheckFor' are high in
+		parameter 'base'.\n
 
 		<h3>Return</h3>
-		Returns true if all bits on in 'field' are on in
-		'in'.\n
+		Returns true if all bits high in 'toCheckFor' are high in 'base'.\n
 
 		<h3>Template</h3>
 		-#  <code>enumT</code> : The enumeration type (preffered) that is to
@@ -51,12 +50,12 @@ namespace enh
 
 	*/
 	template<class enumT>
-	inline bool checkField(
-		enumT in /**< : <i>in</i> : The field to check.*/,
-		enumT field /**< : <i>in</i> : The fields to check for.*/
+	inline constexpr bool checkField(
+		enumT base /**< : <i>base</i> : The toCheckFor to check.*/,
+		enumT toCheckFor /**< : <i>base</i> : The fields to check for.*/
 	) noexcept
 	{
-		return ((in | field) == in);
+		return ((base | toCheckFor) == base);
 	}
 
 	/**
@@ -116,13 +115,74 @@ namespace enh
 	*/
 	template<class integral>
 	constexpr integral incl_ratio(
-		integral num /*< : <i>in</i> : The numerator of fraction.*/,
-		integral denom /*< : <i>in</i> : The denominator of fraction.*/
+		integral num /*< : <i>base</i> : The numerator of fraction.*/,
+		integral denom /*< : <i>base</i> : The denominator of fraction.*/
 	)
 	{
-		static_assert(std::is_integral_v<integral> &&
-			std::is_unsigned_v < integral>, "inclusive ratio is for integral types");
+		static_assert(std::is_integral_v<integral>, "inclusive ratio is for integral types");
 		return (num / denom) + signum_fn(num % denom);
+	}
+
+	/**
+		\brief Checks if the value is within bounds.
+
+		<h3>Template</h3>
+		<code>class type</code> : Any type that can be compared using <, >, ==.
+
+		<h3>Return</h3>
+		Returns if unChecked is within interval :
+
+		<table>
+			<tr>
+				<th> lInclusive </th>
+				<th> uInclusive </th>
+				<th> Interval </th>
+			</tr>
+			<tr>
+				<th> false </th>
+				<th> false </th>
+				<th> Non-inclusive (lBounds, uBounds) </th>
+			</tr>
+			<tr>
+				<th> false </th>
+				<th> true </th>
+				<th> Upper Bound inclusive (lBounds, uBounds] </th>
+			</tr>
+			<tr>
+				<th> true </th>
+				<th> false </th>
+				<th> Lower Bound inclusive [lBounds, uBounds) </th>
+			</tr>
+			<tr>
+				<th> true </th>
+				<th> true </th>
+				<th> Inclusive [lBounds, uBounds] </th>
+			</tr>
+		</table>
+
+	*/
+	template<class type>
+	constexpr bool isConfined(
+		type unChecked /*< : <i>in</i> : The value to check.*/,
+		type lBounds /*< : <i>in</i> : The Lower bound of the interval.*/,
+		type uBounds /*< : <i>in</i> : The Upper bound of the interval.*/,
+		bool lInclusive = false /*< : <i>in</i> : inclusive lower bound?.*/,
+		bool uInclusive = false /*< : <i>in</i> : inclusive upper bound?.*/
+	)
+	{
+		bool lCheck(false), uCheck(false);
+
+		if (unChecked < uBounds)
+			uCheck = true;
+		else if ((unChecked == uBounds) && uInclusive)
+			uCheck = true;
+
+		if (unChecked > lBounds)
+			lCheck = true;
+		else if ((unChecked == lBounds) && lInclusive)
+			lCheck = true;
+
+		return lCheck && uCheck;
 	}
 
 }

--- a/src/Header/queued_process.enh.h
+++ b/src/Header/queued_process.enh.h
@@ -30,7 +30,7 @@
 #define QUEUED_PROCESS_ENH_H						queued_process.enh.h
 
 #include "logger.enh.h"
-#include "common.enh.h"
+#include "error_base.enh.h"
 
 #include <mutex>
 #include <queue>


### PR DESCRIPTION
* Renamed `common.enh.h` to `error_base.enh.h`
* Moved `CheckField`, `signum`, `inclusive_ratio` to new file `general.enh.h`
* Added `signum_fn`, `incl_ratio`, made `signum` `inclusive_ratio` deprecated.