### PR TITLE
Date time literal type

### DIFF
--- a/src/Header/date.enh.h
+++ b/src/Header/date.enh.h
@@ -275,7 +275,7 @@ namespace enh
 			not within bounds. [0,month_limit], [0,11], [0,6], [0,year_limit)
 			respectively.
 		*/
-		inline date(
+		constexpr inline date(
 			unsigned short dy /**< : <i>in</i> : The day of the month
 							  [1,month_limit].*/,
 			unsigned short mnth /**< : <i>in</i> : The number of months after
@@ -285,9 +285,18 @@ namespace enh
 								Sunday [0,6].*/,
 			unsigned ydy /**< : <i>in</i> : The number of day after 01 January
 						 of that year [1,year_limit).*/
-		)
+		) : day(dy), month(mnth), year(yr), wkday(week), yrday(ydy)
 		{
-			setDate(dy, mnth, yr, week, ydy);
+			if (!isConfined<unsigned short>(week, 0, 7, true, false))
+				throw std::invalid_argument("Week day should be in range [0,6]");
+			if (!isConfined<unsigned short>(mnth, 0, 12, true, false))
+				throw std::invalid_argument("Month should be in range [0,11]");
+			if (!isConfined<unsigned short>(dy, 1, month_limit(mnth, yr), true, true))
+				throw std::invalid_argument("day should be within the monthly "
+					"maximum (28,29,30 or 31 according to month).");
+			if (!isConfined(ydy, 0u, year_limit(yr), true, false))
+				throw std::invalid_argument("year day should be less than "
+					"that for that year (365,366).");
 		}
 
 		/**
@@ -312,12 +321,12 @@ namespace enh
 		/**
 			\brief The day of this month.
 		*/
-		inline unsigned short getDayOfMonth() const noexcept { return day; }
+		constexpr inline unsigned short getDayOfMonth() const noexcept { return day; }
 
 		/**
 			\brief The number of months after January of this year.
 		*/
-		inline unsigned short getMonth() const noexcept { return month; }
+		constexpr inline unsigned short getMonth() const noexcept { return month; }
 
 		/**
 			\brief The name of the month.
@@ -368,18 +377,18 @@ namespace enh
 		/**
 			\brief The Year.
 		*/
-		inline long getYear() const noexcept { return year; }
+		constexpr inline long getYear() const noexcept { return year; }
 
 		/**
 			\brief The number of days after last Sunday.
 		*/
-		inline unsigned short getDayOfWeek() const noexcept { return wkday; }
+		constexpr inline unsigned short getDayOfWeek() const noexcept { return wkday; }
 
 
 		/**
 			\brief The number of days after 1st of January this year.
 		*/
-		inline unsigned getDayOfYear() const noexcept { return yrday; }
+		constexpr inline unsigned getDayOfYear() const noexcept { return yrday; }
 
 		/**
 			\brief The name of the day.

--- a/src/Header/date_time.enh.h
+++ b/src/Header/date_time.enh.h
@@ -96,7 +96,7 @@ namespace enh
 			\brief Sets the time and date to the time and date indicated by
 			argument.
 		*/
-		inline DateTime(
+		constexpr inline DateTime(
 			unsigned short dy /**< : <i>in</i> : The day of the month
 							  [1,month_limit].*/,
 			unsigned short mnth /**< : <i>in</i> : The number of months after
@@ -118,12 +118,18 @@ namespace enh
 		inline DateTime(
 			time_t stamp /**< : <i>in</i> : The time stamp which
 							 contains the date and time.*/
-		) : date(stamp), time_stamp(stamp) {}
+		) : date(0,0,0,0,0), time_stamp(0,0,0) 
+		{
+			set(stamp);
+		}
 
 		/**
 			\brief Sets the time and date to the current time and date.
 		*/
-		inline DateTime() : date(), time_stamp() {}
+		inline DateTime() : date(0, 0, 0, 0, 0), time_stamp(0, 0, 0) 
+		{
+			set();
+		}
 
 		/**
 			\brief Get The date and time as a string in default format.

--- a/src/Header/framework.enh.h
+++ b/src/Header/framework.enh.h
@@ -124,7 +124,7 @@ namespace enh
 			-# <code>inline version_info(unsigned, unsigned, unsigned, unsigned,
 			enh::rel_type, std::string_view) noexcept;</code>\n
 		*/
-		inline version_info() noexcept :major(0), minor(0), revision(0),
+		constexpr inline version_info() noexcept :major(0), minor(0), revision(0),
 			build(0), type(rel_type::BETA) { }
 
 		/**

--- a/src/Header/time_stamp.enh.h
+++ b/src/Header/time_stamp.enh.h
@@ -114,13 +114,21 @@ namespace enh
 			Throws <code>std::invalid_argument</code> if sec, min, hr is
 			not within bounds. [0,60], [0,59], [0,23] respectively.
 		*/
-		inline time_stamp(
+		constexpr inline time_stamp(
 			unsigned short sec /**< : <i>in</i> : The seconds field [0,60].*/,
 			unsigned short min /**< : <i>in</i> : The minutes field [0,59].*/,
 			unsigned short hr  /**< : <i>in</i> : The hours field [0,59].*/
-		)
+		) : seconds(sec), minutes(min), hours(hr)
 		{
-			setTime(sec, min, hr);
+			if (!isConfined<unsigned short>(sec, 0, 60, true, true))
+				throw std::invalid_argument("Seconds should be in range"
+					" [0,60]");
+			if (!isConfined<unsigned short>(min, 0, 59, true, true))
+				throw std::invalid_argument("Minutes should be in range"
+					" [0,59]");
+			if (!isConfined<unsigned short>(hr, 0, 23, true, true))
+				throw std::invalid_argument("Hours should be in range"
+					" [0,23]");
 		}
 
 		/**
@@ -201,17 +209,17 @@ namespace enh
 		/**
 			\brief Get Seconds field.
 		*/
-		inline unsigned short getSeconds() const noexcept { return seconds; }
+		constexpr inline unsigned short getSeconds() const noexcept { return seconds; }
 
 		/**
 			\brief Get Minutes field.
 		*/
-		inline unsigned short getMinutes() const noexcept { return minutes; }
+		constexpr inline unsigned short getMinutes() const noexcept { return minutes; }
 
 		/**
 			\brief Get Hours field.
 		*/
-		inline unsigned short getHours() const noexcept { return hours; }
+		constexpr inline unsigned short getHours() const noexcept { return hours; }
 
 		/**
 			\brief Get The time as a string in default format.


### PR DESCRIPTION
* Made classes `DateTime`, `date`, `time_stamp` literal types by making constructor `constexpr` as well as getters.
* Removed multiple calls to `time()` and `localtime()` in `DateTime` class due to both base class calling them, unified to single call.
